### PR TITLE
Fixes ARK-1510

### DIFF
--- a/ark-common/src/main/java/au/org/theark/core/audit/AuditThreadLocalHelper.java
+++ b/ark-common/src/main/java/au/org/theark/core/audit/AuditThreadLocalHelper.java
@@ -1,0 +1,7 @@
+package au.org.theark.core.audit;
+
+public class AuditThreadLocalHelper {
+
+	public static ThreadLocal<String> USERNAME = new ThreadLocal<String>();
+	
+}

--- a/ark-common/src/main/java/au/org/theark/core/audit/UsernameRevisionListener.java
+++ b/ark-common/src/main/java/au/org/theark/core/audit/UsernameRevisionListener.java
@@ -8,7 +8,19 @@ public class UsernameRevisionListener implements RevisionListener {
 	@Override
 	public void newRevision(Object revisionEntity) {
 		UsernameRevisionEntity ure = (UsernameRevisionEntity) revisionEntity;
-		ure.setUsername(SecurityUtils.getSubject().getPrincipal().toString());
+		
+		try {
+			ure.setUsername(SecurityUtils.getSubject().getPrincipal().toString());
+		} catch (Exception e) {
+			
+			e.printStackTrace();
+			
+			if(Thread.currentThread().getName().contains("Quartz")) { //If this is being called from a background thread
+				System.out.println(AuditThreadLocalHelper.USERNAME.get());
+				ure.setUsername(AuditThreadLocalHelper.USERNAME.get());
+			}	
+		}
+			
 	}
 
 }

--- a/ark-phenotypic/src/main/java/au/org/theark/phenotypic/job/CustomDataUploadExecutor.java
+++ b/ark-phenotypic/src/main/java/au/org/theark/phenotypic/job/CustomDataUploadExecutor.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.shiro.SecurityUtils;
 import org.jfree.util.Log;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
@@ -118,7 +119,8 @@ public class CustomDataUploadExecutor {
 		customDataUploadJob.getJobDataMap().put(CustomDataUploadJob.LIST_OF_UIDS_TO_UPDATE, uidsToUpload);
 		customDataUploadJob.getJobDataMap().put(CustomDataUploadJob.PHENO_COLLECTION, phenoCollection);
 		customDataUploadJob.getJobDataMap().put(CustomDataUploadJob.CUSTOM_FIELD_GROUP, customFieldGroup);
-		customDataUploadJob.getJobDataMap().put("overwrite", overwriteExisting);
+		customDataUploadJob.getJobDataMap().put(CustomDataUploadJob.OVERWRITE_EXISTING, overwriteExisting);
+		customDataUploadJob.getJobDataMap().put(CustomDataUploadJob.USERNAME, SecurityUtils.getSubject().getPrincipal().toString());
 		
 		Date startTime = nextGivenSecondDate(null, 1);
 		

--- a/ark-phenotypic/src/main/java/au/org/theark/phenotypic/job/CustomDataUploadJob.java
+++ b/ark-phenotypic/src/main/java/au/org/theark/phenotypic/job/CustomDataUploadJob.java
@@ -30,11 +30,12 @@ import org.quartz.JobExecutionException;
 import org.quartz.PersistJobDataAfterExecution;
 
 import au.org.theark.core.Constants;
+import au.org.theark.core.audit.AuditThreadLocalHelper;
 import au.org.theark.core.model.pheno.entity.PhenoCollection;
 import au.org.theark.core.model.study.entity.CustomFieldGroup;
 import au.org.theark.core.model.study.entity.Upload;
 import au.org.theark.core.service.IArkCommonService;
-import au.org.theark.phenotypic.service.*;
+import au.org.theark.phenotypic.service.IPhenotypicService;
 
 /**
  * @author tendersby
@@ -58,6 +59,8 @@ public class CustomDataUploadJob implements Job {
 	public static final String		REPORT				= "report";
 	public static final String		LIST_OF_UIDS_TO_UPDATE	= "listOfUidsToUpdate";
 	public static final String		CUSTOM_FIELD_GROUP = "customFieldGroup";
+	public static final String		OVERWRITE_EXISTING = "overwriteExisting";
+	public static final String		USERNAME 			= "username";
 	
 	private 	IPhenotypicService	iPhenoService;
 	private 	IArkCommonService<Void>	iArkCommonService;
@@ -89,7 +92,10 @@ public class CustomDataUploadJob implements Job {
 		List<String> uidsToUpdate=(List<String>)data.get(LIST_OF_UIDS_TO_UPDATE);
 		CustomFieldGroup customFieldGroup = (CustomFieldGroup) data.get(CUSTOM_FIELD_GROUP);
 		PhenoCollection phenoCollection = (PhenoCollection) data.get(PHENO_COLLECTION);
-		boolean overwriteExisting = data.getBoolean("overwrite");
+		boolean overwriteExisting = data.getBoolean(OVERWRITE_EXISTING);
+		String username 			= data.getString(USERNAME);
+		
+		AuditThreadLocalHelper.USERNAME.set(username);
 		
 		try {
 			Date startTime = new Date(System.currentTimeMillis());


### PR DESCRIPTION
Where in a background thread (i.e an uploader) the subject context may be lost and so it is preventing the uploads being saved. We now save the username at the instant the thread is created and then store it in a ThreadLocal to be read by the UsernameRevisionListener
