### PR TITLE
Updated mysql Dockerfile to extend mysql:5 instead of mysql:latest

### DIFF
--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:latest
+FROM mysql:5
 
 MAINTAINER George Gooden <gecgooden@gmail.com>
 


### PR DESCRIPTION
Tried setting up the project using Docker and found that the mysql:latest image is now pointing at MySQL version 8 so I updated the Dockerfile to build from mysql:5 instead.