### PR TITLE
Fix Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,9 @@ services:
         - docker
 env:
         DOCKER_COMPOSE_VERSION: 1.11.1
+
 before_install:
-        - sudo apt-get update
-        - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
-        - sudo rm /usr/local/bin/docker-compose
         - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
         - sudo /etc/init.d/mysql stop
-
-notifications:
-        email:
-                recipients:
-                        - gecgooden@gmail.com 
-                on_success: always
-                on_failure: always

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -2,13 +2,7 @@ FROM the-ark/base:latest
 
 MAINTAINER George Gooden <gecgooden@gmail.com>
 
-RUN echo "deb http://packages.linuxmint.com debian import" >> /etc/apt/sources.list && \
-	gpg --keyserver pgp.mit.edu --recv-keys 3EE67F3D0FF405B2 && \
-	gpg --export 3EE67F3D0FF405B2 > 3EE67F3D0FF405B2.gpg && \
-	apt-key add ./3EE67F3D0FF405B2.gpg && \
-	rm ./3EE67F3D0FF405B2.gpg
-
-RUN apt-get update && apt-get install -y firefox xvfb ffmpeg tmux mysql-client
+RUN apt-get update && apt-get install -y firefox-esr xvfb ffmpeg tmux mysql-client
 
 ADD . /test/
 


### PR DESCRIPTION
Travis-CI builds were failing because of issues with the before_install stage and the Linux Mint firefox package in the test Docker image.

Removed offending sections from the travis.yml file and changed the test image to use the debian firefox-est package