### PR TITLE
Add additional JDK build versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ jdk:
   - oraclejdk9
   - oraclejdk11
 
+matrix:
+  allow_failures:
+    - jdk: openjdk11
+    - jdk: oraclejdk11
+
 before_install:
   - mvn initialize
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ jdk:
   - openjdk8
   - openjdk10
   - openjdk11
-  - oraclejdk9
   - oraclejdk11
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 
 jdk:
   - openjdk8
+  - openjdk10
+  - openjdk11
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
 
 before_install:
   - mvn initialize

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,15 @@ jdk:
   - openjdk8
   - openjdk10
   - openjdk11
-  - oraclejdk8
   - oraclejdk9
   - oraclejdk11
 
 matrix:
+  include:
+    - jdk: oraclejdk9
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
   allow_failures:
     - jdk: openjdk11
     - jdk: oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ matrix:
     - jdk: openjdk11
     - jdk: oraclejdk11
 
-before_install:
+install:
   - mvn initialize
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 cache:
   directories:


### PR DESCRIPTION
By adding more JDK versions, we can be sure that The Ark at least builds successfully on those JDK versions.