### PR TITLE
ARK-1944 Remove phenodata from the data set it exists in

### DIFF
--- a/ark-phenotypic/src/main/java/au/org/theark/phenotypic/service/PhenotypicServiceImpl.java
+++ b/ark-phenotypic/src/main/java/au/org/theark/phenotypic/service/PhenotypicServiceImpl.java
@@ -245,6 +245,7 @@ public class PhenotypicServiceImpl implements IPhenotypicService {
 					Long count = phenotypicDao.isPhenoDataSetFieldUsed(phenoData);
 
 					phenotypicDao.deletePhenoData(phenoData);
+					phenoData.getPhenoDataSetCollection().getPhenoDataSetData().remove(phenoData);
 					if (count <= 1) {
 						// Then update the PhenoDataSetField hasDataFlag to false.Reload since the session was closed in the front end and the child objects won't be loaded
 						Long id = phenoData.getPhenoDataSetFieldDisplay().getPhenoDataSetField().getId();


### PR DESCRIPTION
There is an exception thrown when deleting the `phenoData` object as it still exists within a `PhenoDataSetCollection`. Hibernate will attempt to re-save the `phenoData` object as it still exists within that collection.