### PR TITLE
Set initial biotransaction unit type

### DIFF
--- a/ark-lims/src/main/java/au/org/theark/lims/util/BioCollectionSpecimenUploader.java
+++ b/ark-lims/src/main/java/au/org/theark/lims/util/BioCollectionSpecimenUploader.java
@@ -612,6 +612,7 @@ public class BioCollectionSpecimenUploader {
 				bioTransaction.setTransactionDate(Calendar.getInstance().getTime());
 				bioTransaction.setQuantity(biospecimen.getQuantity());
 				bioTransaction.setReason(au.org.theark.lims.web.Constants.BIOTRANSACTION_STATUS_INITIAL_QUANTITY);
+				bioTransaction.setUnit(biospecimen.getUnit());
 					
 				BioTransactionStatus initialStatus = iLimsService.getBioTransactionStatusByName(au.org.theark.lims.web.Constants.BIOTRANSACTION_STATUS_INITIAL_QUANTITY);
 				bioTransaction.setStatus(initialStatus);	//ensure that the initial transaction can be identified


### PR DESCRIPTION
When uploading biospecimens, we create an initial biotransaction containing details from the biospecimen being uploaded. We were missing setting the unit on the transaction (which is a required property).